### PR TITLE
Ability to specify port #-

### DIFF
--- a/rosstalk.js
+++ b/rosstalk.js
@@ -87,7 +87,7 @@ instance.prototype.config_fields = function () {
 			width: 6,
 			default: "7788",
 			regex: self.REGEX_NUMBER
-		},
+		}
 	]
 };
 

--- a/rosstalk.js
+++ b/rosstalk.js
@@ -85,6 +85,7 @@ instance.prototype.config_fields = function () {
 			id: 'port',
 			label: 'Switcher Frame/XPression Port',
 			width: 6,
+			default: "7788",
 			regex: self.REGEX_NUMBER
 		},
 	]

--- a/rosstalk.js
+++ b/rosstalk.js
@@ -41,7 +41,7 @@ instance.prototype.init_tcp = function() {
 	}
 
 	if (self.config.host) {
-		self.socket = new tcp(self.config.host, 7788);
+		self.socket = new tcp(self.config.host, self.config.port);
 
 		self.socket.on('status_change', function (status, message) {
 			self.status(status, message);
@@ -79,6 +79,13 @@ instance.prototype.config_fields = function () {
 			label: 'Switcher Frame/XPression IP',
 			width: 6,
 			regex: self.REGEX_IP
+		},
+		{
+			type: 'textinput',
+			id: 'port',
+			label: 'Switcher Frame/XPression Port',
+			width: 6,
+			regex: self.REGEX_NUMBER
 		},
 	]
 };


### PR DESCRIPTION
I've updated rosstalk.js to have the ability to specify a port number.  This is my first attempt at programming for Companion, so feel free to criticize!  

I tested it using VirtualBox and Ubuntu with the web emulator...I haven't tested with USB plugged in.  I ran 2 different Ross Dashboard instances side by side (on ports 7795 and 7796) and it seemed to work great.

Let me know if you have any questions/concerns.  Thanks!


Bo
@sailingbo
